### PR TITLE
Update pab_manifest.c

### DIFF
--- a/platforms/common/pab_manifest.c
+++ b/platforms/common/pab_manifest.c
@@ -357,6 +357,7 @@ static const px4_hw_mft_item_t base_configuration_17[] = {
 };
 
 // BASE ID 0x100 Holybro Pixhawk Jetson Baseboard Alaised to ID 0
+// BASE ID 0x150 ZeroOne Pixhawk Baseboard Alaised to ID 0
 
 static px4_hw_mft_list_entry_t mft_lists[] = {
 //  ver_rev


### PR DESCRIPTION
I have updated pab_manifest.c:
// BASE ID 0x150 ZeroOne Pixhawk Baseboard Alaised to ID 0
{HW_BASE_ID(0x150),  base_configuration_0, arraySize(base_configuration_0)},   // ZeroOne Pixhawk Baseboard ver 0x150